### PR TITLE
Allow CI steps to continue on error

### DIFF
--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -48,6 +48,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Standardized Node.js Setup
+        continue-on-error: true
         uses: ./.github/workflows/setup
         with:
           node-version: 20
@@ -137,6 +138,7 @@ jobs:
           echo "moderate=$MOD" >> $GITHUB_OUTPUT
           
       - name: Performance Analysis
+        continue-on-error: true
         id: perf
         if: steps.build.outcome == 'success'
         run: |
@@ -190,6 +192,7 @@ jobs:
           token: ${{ secrets.GH_TOKEN }}
 
       - name: Standardized Node.js Setup
+        continue-on-error: true
         uses: ./.github/workflows/setup
         with:
            install-deps: 'true'
@@ -241,6 +244,7 @@ jobs:
           npx tsx scripts/generate-health-report.ts
 
       - name: Save Report to Agent Workspace
+        continue-on-error: true
         if: always()
         run: |
           # 1. Temporarily save the generated report


### PR DESCRIPTION
Added 'continue-on-error: true' to multiple steps in the CI workflow to allow the workflow to proceed even if these steps fail.